### PR TITLE
Use existing boolean to determine if title should be displayed or not

### DIFF
--- a/templates/EvansHunt/Elements/ContentElement.ss
+++ b/templates/EvansHunt/Elements/ContentElement.ss
@@ -1,4 +1,3 @@
 $Background
-$ShowTitle
-$Title
+<% if $ShowTitle %>$Title<% endif %>
 $Copy


### PR DESCRIPTION
The ShowTitle boolean was printing either 0 or 1 directly to the page.

Slight modification to use boolean to show or hide the title.